### PR TITLE
Removing Sentry browser tracing because it gets blocked by uBlock (ad blocker)

### DIFF
--- a/app/assets/javascripts/sentry.js.erb
+++ b/app/assets/javascripts/sentry.js.erb
@@ -1,6 +1,9 @@
+try {
+    Sentry.init({
+        dsn: '<%= ENV['SENTRY_DSN'] %>'
+    });
+}
+catch(err) {
+    console.log('Javascript error capturing disabled.');
+}
 
-Sentry.init({
-  dsn: '<%= ENV['SENTRY_DSN'] %>',
-  integrations: [new Sentry.Integrations.BrowserTracing()],
-  tracesSampleRate: 1.0,
-});

--- a/app/views/layouts/blacklight/base.html.erb
+++ b/app/views/layouts/blacklight/base.html.erb
@@ -15,8 +15,8 @@
     <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
   <![endif]-->
   <script
-    src="https://browser.sentry-cdn.com/6.3.0/bundle.tracing.min.js"
-    integrity="sha384-bYnMk4rdUJ32XikJR2cXhgirS37DAde7poz0I7hPFWkmGzvhHs1TXBHlU8Gv+hQn"
+    src="https://browser.sentry-cdn.com/6.3.0/bundle.min.js"
+    integrity="sha384-WgORxZTgCBZ7OuRalW7vYFXjvpXNZavDV8wWQWVbaNd57Ht4aYBVD1rRcz8dlyUM"
     crossorigin="anonymous"
   ></script>
   <%= javascript_include_tag 'application' %>


### PR DESCRIPTION
Added a try catch just in case Sentry still get's blocked so it won't interfere with other javascript on the page.