### PR TITLE
Bug fix: relation browsing requires a defined facet field

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -127,6 +127,8 @@ class CatalogController < ApplicationController
 
     config.add_facet_field Settings.FIELDS.TYPE, label: 'Type', limit: 8
 
+    config.add_facet_field Settings.FIELDS.SOURCE, :label => 'Source', :limit => 8, collapse: false
+
     # Have BL send all facet field names to Solr, which has been the default
     # previously. Simply remove these lines if you'd rather use Solr request
     # handler defaults, or have no facets.

--- a/test/system/show_page_test.rb
+++ b/test/system/show_page_test.rb
@@ -57,4 +57,14 @@ class ShowPageTest < ApplicationSystemTestCase
       assert page.has_selector?("span.blacklight-icon-table")# Table icon
     end
   end
+
+  def test_show_page_relations_link
+    visit "/catalog/princeton-1r66j405w"
+
+    # Browse Relations
+    click_link("Browse all 4 records...")
+    within("span.page-entries") do
+      assert page.has_content?("4")
+    end
+  end
 end


### PR DESCRIPTION
This addresses the issue we observed when trying to browse relations.

Fixes #95